### PR TITLE
fix package linking

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -7,14 +7,7 @@
     "@semantic-release/release-notes-generator",
     "@semantic-release/npm",
     "@semantic-release/git",
-    [
-      "@semantic-release/github",
-      {
-        "assets": [
-          "build/**"
-        ]
-      }
-    ],
+    "@semantic-release/github",
     "@semantic-release/changelog"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/fredrikj31/toggle-kit.git"
+    "url": "git+https://github.com/fredrikj31/toggle-kit.git"
   },
   "keywords": [
     "feature flagging",


### PR DESCRIPTION
- **ci(semantic-release): removes assets from @semantic-release/github plugin**
- **fix(package.json): adds "git+" to repository url**
